### PR TITLE
Three 143 compatibility

### DIFF
--- a/dist/three-particle-fire.js
+++ b/dist/three-particle-fire.js
@@ -45,7 +45,7 @@
 
 		var Geometry = function Geometry(radius, height, particleCount) {
 
-			THREE.BufferGeometry.call(this);
+			var geometry = new THREE.BufferGeometry();
 
 			var halfHeight = height * 0.5;
 			var position = new Float32Array(particleCount * 3);
@@ -71,12 +71,11 @@
 				}
 			}
 
-			this.addAttribute('position', new THREE.BufferAttribute(position, 3));
-			this.addAttribute('randam', new THREE.BufferAttribute(randam, 1));
-			this.addAttribute('sprite', new THREE.BufferAttribute(sprite, 1));
+			geometry.setAttribute('position', new THREE.BufferAttribute(position, 3));
+			geometry.setAttribute('randam', new THREE.BufferAttribute(randam, 1));
+			geometry.setAttribute('sprite', new THREE.BufferAttribute(sprite, 1));
+			return geometry;
 		};
-
-		Geometry.prototype = Object.create(THREE.BufferGeometry.prototype);
 
 		return Geometry;
 	}
@@ -114,18 +113,18 @@
 			var uniforms = {
 				color: { type: "c", value: null },
 				size: { type: "f", value: 0.0 },
-				texture: { type: "t", value: getTexture() },
+				map: { type: "t", value: getTexture() },
 				time: { type: "f", value: 0.0 },
 				heightOfNearPlane: { type: "f", value: 0.0 }
 			};
 
-			THREE.ShaderMaterial.call(this, {
+			var material = new THREE.ShaderMaterial({
 
 				uniforms: uniforms,
 
 				vertexShader: ['attribute float randam;', 'attribute float sprite;', 'uniform float time;', 'uniform float size;', 'uniform float heightOfNearPlane;', 'varying float vSprite;', 'varying float vOpacity;', 'float PI = 3.14;', 'float quadraticIn( float t ) {', 'float tt = t * t;', 'return tt * tt;', '}', 'void main() {', 'float progress = fract( time + ( 2.0 * randam - 1.0 ) );', 'float progressNeg = 1.0 - progress;', 'float ease = quadraticIn( progress );', 'float influence = sin( PI * ease );', 'vec3 newPosition = position * vec3( 1.0, ease, 1.0 );', 'gl_Position = projectionMatrix * modelViewMatrix * vec4( newPosition, 1.0 );', 'gl_PointSize = ( heightOfNearPlane * size ) / gl_Position.w;', 'vOpacity = min( influence * 4.0, 1.0 ) * progressNeg;', 'vSprite = sprite;', '}'].join('\n'),
 
-				fragmentShader: ['uniform vec3 color;', 'uniform sampler2D texture;', 'varying float vSprite;', 'varying float vOpacity;', 'void main() {', 'vec2 texCoord = vec2(', 'gl_PointCoord.x * ' + ONE_SPRITE_ROW_LENGTH + ' + vSprite,', 'gl_PointCoord.y', ');', 'gl_FragColor = vec4( texture2D( texture, vec2( texCoord ) ).xyz * color * vOpacity, 1.0 );', '}'].join('\n'),
+				fragmentShader: ['uniform vec3 color;', 'uniform sampler2D map;', 'varying float vSprite;', 'varying float vOpacity;', 'void main() {', 'vec2 texCoord = vec2(', 'gl_PointCoord.x * ' + ONE_SPRITE_ROW_LENGTH + ' + vSprite,', 'gl_PointCoord.y', ');', 'gl_FragColor = vec4( texture2D( map, texCoord ).xyz * color * vOpacity, 1.0 );', '}'].join('\n'),
 
 				blending: THREE.AdditiveBlending,
 				depthTest: true,
@@ -135,24 +134,27 @@
 
 			});
 
-			this.color = new THREE.Color(0xff2200);
-			this.size = 0.4;
-			this.setValues(parameters);
+			material.color = new THREE.Color(0xff2200);
+			material.size = 0.4;
 
-			this.uniforms.color.value = this.color;
-			this.uniforms.size.value = this.size;
-		};
+			if (parameters !== undefined) {
+				material.setValues(parameters);
+			}
 
-		Material.prototype = Object.create(THREE.ShaderMaterial.prototype);
+			material.uniforms.color.value = material.color;
+			material.uniforms.size.value = material.size;
 
-		Material.prototype.update = function (delta) {
+			material.update = function (delta) {
 
-			this.uniforms.time.value = (this.uniforms.time.value + delta) % 1;
-		};
+				material.uniforms.time.value = (material.uniforms.time.value + delta) % 1;
+			};
 
-		Material.prototype.setPerspective = function (fov, height) {
+			material.setPerspective = function (fov, height) {
 
-			this.uniforms.heightOfNearPlane.value = Math.abs(height / (2 * Math.tan(THREE.Math.degToRad(fov * 0.5))));
+				material.uniforms.heightOfNearPlane.value = Math.abs(height / (2 * Math.tan(THREE.MathUtils.degToRad(fov * 0.5))));
+			};
+
+			return material;
 		};
 
 		return Material;

--- a/dist/three-particle-fire.module.js
+++ b/dist/three-particle-fire.module.js
@@ -39,7 +39,7 @@ function makeGeometryClass() {
 
 	var Geometry = function Geometry(radius, height, particleCount) {
 
-		THREE.BufferGeometry.call(this);
+		var geometry = new THREE.BufferGeometry();
 
 		var halfHeight = height * 0.5;
 		var position = new Float32Array(particleCount * 3);
@@ -65,12 +65,11 @@ function makeGeometryClass() {
 			}
 		}
 
-		this.addAttribute('position', new THREE.BufferAttribute(position, 3));
-		this.addAttribute('randam', new THREE.BufferAttribute(randam, 1));
-		this.addAttribute('sprite', new THREE.BufferAttribute(sprite, 1));
+		geometry.setAttribute('position', new THREE.BufferAttribute(position, 3));
+		geometry.setAttribute('randam', new THREE.BufferAttribute(randam, 1));
+		geometry.setAttribute('sprite', new THREE.BufferAttribute(sprite, 1));
+		return geometry;
 	};
-
-	Geometry.prototype = Object.create(THREE.BufferGeometry.prototype);
 
 	return Geometry;
 }
@@ -108,18 +107,18 @@ function makeMaterialClass() {
 		var uniforms = {
 			color: { type: "c", value: null },
 			size: { type: "f", value: 0.0 },
-			texture: { type: "t", value: getTexture() },
+			map: { type: "t", value: getTexture() },
 			time: { type: "f", value: 0.0 },
 			heightOfNearPlane: { type: "f", value: 0.0 }
 		};
 
-		THREE.ShaderMaterial.call(this, {
+		var material = new THREE.ShaderMaterial({
 
 			uniforms: uniforms,
 
 			vertexShader: ['attribute float randam;', 'attribute float sprite;', 'uniform float time;', 'uniform float size;', 'uniform float heightOfNearPlane;', 'varying float vSprite;', 'varying float vOpacity;', 'float PI = 3.14;', 'float quadraticIn( float t ) {', 'float tt = t * t;', 'return tt * tt;', '}', 'void main() {', 'float progress = fract( time + ( 2.0 * randam - 1.0 ) );', 'float progressNeg = 1.0 - progress;', 'float ease = quadraticIn( progress );', 'float influence = sin( PI * ease );', 'vec3 newPosition = position * vec3( 1.0, ease, 1.0 );', 'gl_Position = projectionMatrix * modelViewMatrix * vec4( newPosition, 1.0 );', 'gl_PointSize = ( heightOfNearPlane * size ) / gl_Position.w;', 'vOpacity = min( influence * 4.0, 1.0 ) * progressNeg;', 'vSprite = sprite;', '}'].join('\n'),
 
-			fragmentShader: ['uniform vec3 color;', 'uniform sampler2D texture;', 'varying float vSprite;', 'varying float vOpacity;', 'void main() {', 'vec2 texCoord = vec2(', 'gl_PointCoord.x * ' + ONE_SPRITE_ROW_LENGTH + ' + vSprite,', 'gl_PointCoord.y', ');', 'gl_FragColor = vec4( texture2D( texture, vec2( texCoord ) ).xyz * color * vOpacity, 1.0 );', '}'].join('\n'),
+			fragmentShader: ['uniform vec3 color;', 'uniform sampler2D map;', 'varying float vSprite;', 'varying float vOpacity;', 'void main() {', 'vec2 texCoord = vec2(', 'gl_PointCoord.x * ' + ONE_SPRITE_ROW_LENGTH + ' + vSprite,', 'gl_PointCoord.y', ');', 'gl_FragColor = vec4( texture2D( map, texCoord ).xyz * color * vOpacity, 1.0 );', '}'].join('\n'),
 
 			blending: THREE.AdditiveBlending,
 			depthTest: true,
@@ -129,24 +128,27 @@ function makeMaterialClass() {
 
 		});
 
-		this.color = new THREE.Color(0xff2200);
-		this.size = 0.4;
-		this.setValues(parameters);
+		material.color = new THREE.Color(0xff2200);
+		material.size = 0.4;
 
-		this.uniforms.color.value = this.color;
-		this.uniforms.size.value = this.size;
-	};
+		if (parameters !== undefined) {
+			material.setValues(parameters);
+		}
 
-	Material.prototype = Object.create(THREE.ShaderMaterial.prototype);
+		material.uniforms.color.value = material.color;
+		material.uniforms.size.value = material.size;
 
-	Material.prototype.update = function (delta) {
+		material.update = function (delta) {
 
-		this.uniforms.time.value = (this.uniforms.time.value + delta) % 1;
-	};
+			material.uniforms.time.value = (material.uniforms.time.value + delta) % 1;
+		};
 
-	Material.prototype.setPerspective = function (fov, height) {
+		material.setPerspective = function (fov, height) {
 
-		this.uniforms.heightOfNearPlane.value = Math.abs(height / (2 * Math.tan(THREE.Math.degToRad(fov * 0.5))));
+			material.uniforms.heightOfNearPlane.value = Math.abs(height / (2 * Math.tan(THREE.MathUtils.degToRad(fov * 0.5))));
+		};
+
+		return material;
 	};
 
 	return Material;

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -10,7 +10,7 @@ canvas{display: block;}
 </head>
 <body>
 
-<script src="https://cdnjs.cloudflare.com/ajax/libs/three.js/88/three.js"></script>
+<script src="https://unpkg.com/three@0.143.0/build/three.js"></script>
 <script src="../dist/three-particle-fire.js"></script>
 <script>
 //
@@ -89,7 +89,7 @@ var ground = new THREE.Mesh(
 	new THREE.MeshPhongMaterial( { map: groundColor } )
 );
 ground.position.y = -1;
-ground.rotation.x = THREE.Math.degToRad( -90 );
+ground.rotation.x = THREE.MathUtils.degToRad( -90 );
 scene.add( ground );
 
 

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -24,7 +24,6 @@ var width  = window.innerWidth,
     scene,
     camera,
     renderer,
-    loader = new THREE.JSONLoader(),
     textureLoader = new THREE.TextureLoader();
 
 scene  = new THREE.Scene();

--- a/readme.md
+++ b/readme.md
@@ -25,12 +25,13 @@ particleFire.install( { THREE: THREE } );
 var fireRadius = 0.5;
 var fireHeight = 3;
 var particleCount = 800;
+var height = window.innerHeight;
 
 var geometry0 = new particleFire.Geometry( fireRadius, fireHeight, particleCount );
 var material0 = new particleFire.Material( { color: 0xff2200 } );
 material0.setPerspective( camera.fov, height );
 var particleFireMesh0 = new THREE.Points( geometry0, material0 );
-scene.add( particleFireMesh );
+scene.add( particleFireMesh0 );
 ```
 
 3. Update on tick in your render loop.

--- a/src/geometry.js
+++ b/src/geometry.js
@@ -7,7 +7,7 @@ export default function makeGeometryClass() {
 
 	const Geometry = function Geometry( radius, height, particleCount ) {
 
-		THREE.BufferGeometry.call( this );
+		const geometry = new THREE.BufferGeometry();
 
 		const halfHeight = height * 0.5;
 		const position = new Float32Array( particleCount * 3 );
@@ -35,13 +35,12 @@ export default function makeGeometryClass() {
 
 		}
 
-		this.addAttribute( 'position', new THREE.BufferAttribute( position, 3 ) );
-		this.addAttribute( 'randam', new THREE.BufferAttribute( randam, 1 ) );
-		this.addAttribute( 'sprite', new THREE.BufferAttribute( sprite, 1 ) );
+		geometry.setAttribute( 'position', new THREE.BufferAttribute( position, 3 ) );
+		geometry.setAttribute( 'randam', new THREE.BufferAttribute( randam, 1 ) );
+		geometry.setAttribute( 'sprite', new THREE.BufferAttribute( sprite, 1 ) );
+		return geometry;
 
 	}
-
-	Geometry.prototype = Object.create( THREE.BufferGeometry.prototype );
 
 	return Geometry;
 

--- a/src/material.js
+++ b/src/material.js
@@ -16,7 +16,7 @@ export default function makeMaterialClass() {
 			heightOfNearPlane: { type: "f", value: 0.0 }
 		};
 
-		THREE.ShaderMaterial.call( this, {
+		const material = new THREE.ShaderMaterial({
 
 			uniforms      : uniforms,
 
@@ -83,26 +83,29 @@ export default function makeMaterialClass() {
 
 		} );
 
-		this.color = new THREE.Color( 0xff2200 );
-		this.size  = 0.4;
-		this.setValues( parameters );
+		material.color = new THREE.Color(0xff2200);
+		material.size = 0.4;
 
-		this.uniforms.color.value = this.color;
-		this.uniforms.size.value  = this.size;
+		if ( parameters !== undefined ) {
+			material.setValues( parameters );
+		}
 
-	}
+		material.uniforms.color.value = material.color;
+		material.uniforms.size.value = material.size;
 
-	Material.prototype = Object.create( THREE.ShaderMaterial.prototype );
+		material.update = function( delta ) {
 
-	Material.prototype.update = function( delta ) {
+			material.uniforms.time.value = ( material.uniforms.time.value + delta ) % 1;
 
-		this.uniforms.time.value = ( this.uniforms.time.value + delta ) % 1;
+		}
 
-	}
+		material.setPerspective = function( fov, height ) {
 
-	Material.prototype.setPerspective = function( fov, height ) {
+			material.uniforms.heightOfNearPlane.value = Math.abs( height / ( 2 * Math.tan( THREE.MathUtils.degToRad( fov * 0.5 ) ) ) );
 
-		this.uniforms.heightOfNearPlane.value = Math.abs( height / ( 2 * Math.tan( THREE.Math.degToRad( fov * 0.5 ) ) ) );
+		}
+
+		return material;
 
 	}
 

--- a/src/material.js
+++ b/src/material.js
@@ -11,7 +11,7 @@ export default function makeMaterialClass() {
 		const uniforms = {
 			color            : { type: "c", value: null },
 			size             : { type: "f", value: 0.0 },
-			texture          : { type: "t", value: getTexture() },
+			map              : { type: "t", value: getTexture() },
 			time             : { type: "f", value: 0.0 },
 			heightOfNearPlane: { type: "f", value: 0.0 }
 		};
@@ -58,7 +58,7 @@ export default function makeMaterialClass() {
 
 			fragmentShader: [
 				'uniform vec3 color;',
-				'uniform sampler2D texture;',
+				'uniform sampler2D map;',
 
 				'varying float vSprite;',
 				'varying float vOpacity;',
@@ -70,7 +70,7 @@ export default function makeMaterialClass() {
 						'gl_PointCoord.y',
 					');',
 
-					'gl_FragColor = vec4( texture2D( texture, vec2( texCoord ) ).xyz * color * vOpacity, 1.0 );',
+					'gl_FragColor = vec4( texture2D( map, texCoord ).xyz * color * vOpacity, 1.0 );',
 
 				'}'
 			].join( '\n' ),


### PR DESCRIPTION
This shader is lit :D thank you for writing it.
I added compatibility with latest threejs.
Extending the constructor the way you did previously didn't work anymore with latest threejs version, I guess since threejs moved to ES6 code, the generated commonjs code bundled with threejs wasn't the same. I used a simple function that return the augmented instance, it's normally the same as before.
I had to rename the uniform `texture` to something else, I chose `map`, `texture` seems to be a reserved keyword now, I had an error like it was a function to be called...
`THREE.Math` alias was removed in latest version, you need to use `THREE.MathUtils`.
`Geometry.addAttribute` doesn't exist anymore, you need to use `Geometry.setAttribute` now.